### PR TITLE
Fix: Correct medical user redirection and ensure center selection

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -32,7 +32,7 @@ export default function LoginPage() {
       if (user.role === "Administrador") {
         setIsAdmin(true); // This will show the admin-specific UI on the login page
       } else if (user.id_Rol === 2) { // 'Médico'
-        router.push('/management/medical/appointments');
+         router.push('/medical/select-center'); // Corrected redirection
       } else if (user.id_Rol === 6) {
         router.push('/management/availability');
       } else {

--- a/frontend/context/auth-context.tsx
+++ b/frontend/context/auth-context.tsx
@@ -73,8 +73,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       console.log('[AuthContext] Admin user detected, redirecting to role selection page (/login).');
       router.push('/login'); // This is the role selection page for admins
     } else if (newUser.id_Rol === 2) { // Role ID for 'Médico'
-      console.log('[AuthContext] Redirecting to /management/medical/appointments');
-      router.push('/management/medical/appointments');
+      console.log('[AuthContext] Redirecting to /medical/select-center'); // Corrected redirection
+      router.push('/medical/select-center'); // Corrected redirection
     } else if (newUser.id_Rol === 6) { // Role ID for 'Tutor'
       // Assuming Tutors go to /management/availability or /dashboard. User has this as /management/availability.
       console.log('[AuthContext] User with role', newUser.id_Rol, 'redirecting to /management/availability');
@@ -88,14 +88,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     localStorage.clear();
     setToken(null);
     setUser(null);
-<<<<<<< HEAD
-    router.push('/auth');
-  };
-=======
-    setSelectedCenterState(null);
-    router.push('/login');
+    setSelectedCenterState(null); // This is the desired version
+    router.push('/login');        // This is the desired version
   }, [router]);
->>>>>>> 59c15ca7545046203f0de3a1afdef9b8d44ac9fe
 
   const handleSetSelectedCenter = useCallback((center: MedicalCenter | null) => {
     if (center) {


### PR DESCRIPTION
- Resolved merge conflict in AuthContext logout function.
- Updated post-login redirection for medical users (id_Rol=2) to point to the 'select-center' page instead of directly to appointments.
- This ensures that medical users are prompted to select a center before viewing appointments, and the selected center's ID is correctly used when fetching appointment data.