### PR TITLE
Refactor: Improve API error message handling in useApi hook

### DIFF
--- a/frontend/hooks/use-api.ts
+++ b/frontend/hooks/use-api.ts
@@ -53,8 +53,15 @@ const useApi = <T = any>() => {
           if (response.status === 401 || response.status === 403) {
             logout();
           }
-          const errorData = await response.json().catch(() => ({ message: response.statusText }));
-          throw new Error(errorData.message || 'An error occurred');
+          let errorResponseMessage = `Request failed with status ${response.status}`;
+          try {
+            const errorData = await response.json();
+            errorResponseMessage = errorData.message || errorData.error || errorResponseMessage;
+          } catch (e) {
+            // If parsing JSON fails, use statusText or the generic message
+            errorResponseMessage = response.statusText || errorResponseMessage;
+          }
+          throw new Error(errorResponseMessage);
         }
 
         if (response.status === 204) {


### PR DESCRIPTION
Enhanced the `useApi` hook to provide more descriptive error messages when API calls fail.

- If an API request is not `ok`, the error message will now include the HTTP status code.
- Attempts to parse the error response as JSON and uses `errorData.message` or `errorData.error` if available.
- Falls back to `response.statusText` or the status-based message if JSON parsing fails or the specific fields are not present.

This will help in better diagnosing issues if the API returns errors, particularly for the medical appointments view.