### PR TITLE
Fix: Ensure error message in useApi is always a string

### DIFF
--- a/frontend/components/medical/medical-appointments-view.tsx
+++ b/frontend/components/medical/medical-appointments-view.tsx
@@ -38,7 +38,7 @@ export function MedicalAppointmentsView() {
       toast({
         variant: "destructive",
         title: "Error",
-        description: "No se pudieron cargar las citas médicas",
+        description: error instanceof Error ? error.message : "No se pudieron cargar las citas médicas",
       });
     }
   }, [fetchAppointments, user?.id, selectedCenter, toast]);

--- a/frontend/hooks/use-api.ts
+++ b/frontend/hooks/use-api.ts
@@ -54,12 +54,24 @@ const useApi = <T = any>() => {
             logout();
           }
           let errorResponseMessage = `Request failed with status ${response.status}`;
+          let parsedErrorData;
           try {
-            const errorData = await response.json();
-            errorResponseMessage = errorData.message || errorData.error || errorResponseMessage;
+            parsedErrorData = await response.json();
           } catch (e) {
-            // If parsing JSON fails, use statusText or the generic message
-            errorResponseMessage = response.statusText || errorResponseMessage;
+            // JSON parsing failed
+            parsedErrorData = null;
+          }
+
+          if (parsedErrorData && typeof parsedErrorData.message === 'string') {
+            errorResponseMessage = parsedErrorData.message;
+          } else if (parsedErrorData && typeof parsedErrorData.error === 'string') {
+            errorResponseMessage = parsedErrorData.error;
+          } else if (response.statusText) {
+            errorResponseMessage = response.statusText;
+          }
+          // Ensure errorResponseMessage is a non-empty string
+          if (!errorResponseMessage || typeof errorResponseMessage !== 'string') {
+            errorResponseMessage = `An error occurred (status ${response.status})`;
           }
           throw new Error(errorResponseMessage);
         }


### PR DESCRIPTION
Updated the useApi hook to ensure that the error message thrown is always a string. This prevents errors that could occur if the API error response or statusText was not providing a string message.

Also updated MedicalAppointmentsView to directly use the error.message from useApi, as it's now guaranteed to be a string.